### PR TITLE
Use uint for baud rate

### DIFF
--- a/BaudRate.cs
+++ b/BaudRate.cs
@@ -1,6 +1,6 @@
-namespace serialapp
+unamespace serialapp
 {
-    public enum BaudRate : long
+    public enum BaudRate : uint
     {
         B1200 = 1200,
         B2400 = 2400,


### PR DESCRIPTION
The baud rate in the libc library is specified as an unsigned long in C/C++ which is actually a uint in C#.